### PR TITLE
認証レルムをWikiごとにセットするようにする

### DIFF
--- a/gyazz.rb
+++ b/gyazz.rb
@@ -53,7 +53,7 @@ get '/:name/*/search' do          # /増井研/合宿/search
   end
   if !password_authorized?(name) then
     if !authorized_by_cookie then
-      response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+      response['WWW-Authenticate'] = %(Basic realm="#{name}")
       throw(:halt, [401, "Not authorized.\n"])
     end
   end
@@ -73,7 +73,7 @@ get "/__search/:name" do |name|
   end
   if !password_authorized?(name) then
     if !authorized_by_cookie then
-      response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+      response['WWW-Authenticate'] = %(Basic realm="#{name}")
       throw(:halt, [401, "Not authorized.\n"])
     end
   end
@@ -211,7 +211,7 @@ def check_auth(name)
   end
   if !password_authorized?(name) then
     if !authorized_by_cookie then
-      response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+      response['WWW-Authenticate'] = %(Basic realm="#{name}")
       throw(:halt, [401, "Not authorized.\n"])
     end
   end
@@ -469,7 +469,7 @@ get '/:name/*' do
   if !password_authorized?(name) then
     if title != ALL_AUTH then
       if !authorized_by_cookie then
-        response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+        response['WWW-Authenticate'] = %(Basic realm="#{name}")
         throw(:halt, [401, "Not authorized.\n"])
       end
     else

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -23,7 +23,7 @@ require 'readdata'
 #
   def protected!(name)
     unless password_authorized?(name)
-      response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+      response['WWW-Authenticate'] = %(Basic realm="#{name}")
       throw(:halt, [401, "Not authorized.\n"])
     end
   end


### PR DESCRIPTION
Basic認証が設定されている2つのWikiを開いている場合、たとえば gyazz.com/hoge とgyazz.com/fuga の両方にbasic認証が設定されている場合に、同じブラウザで同時に２つのページを開いているとそれぞれのタブで操作をするたびにパスワードを要求されるので、Wikiごとに別の認証レルムが設定されるようにしました
