### PR TITLE
bugfix map in listedit

### DIFF
--- a/lib/keyword.rb
+++ b/lib/keyword.rb
@@ -12,7 +12,7 @@ class String
           kw !~ /pdf / && 
           kw !~ /^@/ && 
           kw !~ /::/ && 
-          kw !~ /^([EWNSZ][0-9\.]+)+$/ &&
+          kw !~ /^([EWNSZ][1-9][0-9\.]*)+$/ &&
           kw !~ /^[a-fA-F0-9]{32}/ then
         a << kw
       end
@@ -24,7 +24,7 @@ class String
           kw !~ /pdf / && 
           kw !~ /^@/ && 
           kw !~ /::/ && 
-          kw !~ /^([EWNSZ][0-9\.]+)+$/ &&
+          kw !~ /^([EWNSZ][1-9][0-9\.]*)+$/ &&
           kw !~ /^[a-fA-F0-9]{32}/ then
         a << kw
       end

--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -677,7 +677,7 @@ function tag(s,line){
 	else if(t = inner.match(/^([a-fA-F0-9]{32})\.(\w+) (.*)$/)){ // (MD5).ext をpitecan.com上のデータにリンク (2010 5/1)
 	    matched.push('<a href="http://masui.sfc.keio.ac.jp/' + t[1] + '.' + t[2] + '" class="link">' + t[3] + '</a>');
 	}
-	else if(t = inner.match(/^([EWNSZ])([0-9\.]+)(.*)$/)){
+	else if(t = inner.match(/^([EWNSZ])([1-9][0-9\.]*)(.*)$/)){
 	    var o = parseloc(inner);
 	    var s = "\
               <div id='map' style='width:300px;height:300px'></div>\
@@ -706,7 +706,7 @@ function tag(s,line){
                      o.lat = latlng.lat();\
                      o.zoom = map.getZoom();\
                      for(var i=0;i<data.length;i++){\
-                       data[i] = data[i].replace(/\\[\\[([EWNSZ][0-9\.]+)+\\]\\]/,'[['+locstr(o)+']]');\
+                       data[i] = data[i].replace(/\\[\\[([EWNSZ][1-9][0-9\.]*)+\\]\\]/,'[['+locstr(o)+']]');\
                      }\
                      writedata();\
                   });\

--- a/public/javascripts/location.js
+++ b/public/javascripts/location.js
@@ -33,7 +33,7 @@ function parseloc(s){ // 'E130.43.19.70N31.47.47.34Z2' => {130.7221, 31.79648, 2
     o.zoom = 1;
     o.lat = 0.0;
     o.lng = 0.0;
-    while(a = s.match(/^([EWNSZ])([0-9\.]+)(.*)$/)){
+    while(a = s.match(/^([EWNSZ])([1-9][0-9\.]*)(.*)$/)){
 	var v;
 	if(a[2].match(/\..*\./)){
 	    v = loc2val(a[2]);


### PR DESCRIPTION
## バグ

`[[S.M.A.R.T]]` と書くとリンクにならず、地図が埋め込まれてしまうバグがありました。

例
<img src="http://gyazo.com/59f1753ed811c5ce023e2127d5f85939.png">
## 原因

listedit.jsやlocation.jsの正規表現が原因でした

``` javascript
inner.match(/^([EWNSZ])([0-9\.]+)(.*)$/)
```
## 修正

こうしました

``` javascript
inner.match(/^([EWNSZ])([1-9][0-9\.]*)(.*)$/)
```

`[[S.M.A.R.T]]` と書くと、ちゃんとリンクになります
<img src="http://gyazo.com/40160ad0606ca9015bdf97d6be05da65.png">

もちろん既存の緯度経度もmapが表示されます
<img src="http://gyazo.com/ee97247692dfb1ed80068de742161c21.png">
