### PR TITLE
よくあるページタイトルの間違いをasearchでサジェスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem 'rack'
 gem 'sinatra'
 gem 'backports'
 gem 'json'
+gem 'asearch'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    asearch (0.0.1)
     backports (3.3.0)
     json (1.7.7)
     rack (1.5.2)
@@ -16,6 +17,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  asearch
   backports
   json
   rack

--- a/gyazz.rb
+++ b/gyazz.rb
@@ -351,6 +351,16 @@ get '/:name/*/text/:version' do      # 古いバージョンを取得
       data = randomize(data)
     end
   end
+  # 新規ページ作成時、大文字小文字を間違えたページが既に作られていないかチェック
+  if !data or data.strip.empty? or data.strip == "(empty)"
+    similar_titles = similar_page_titles(name, title)
+    unless similar_titles.empty?
+      suggest_title = similar_titles.sort{|a,b|
+        readdata(name, b).size <=> readdata(name, a).size  # 一番大きいページをサジェスト
+      }.first
+      data = "\n-> [[#{suggest_title}]]" if suggest_title
+    end
+  end
   data
 end
 


### PR DESCRIPTION
## 問題

既に`MacRuby`というページがあるのに、`macruby`や`mac ruby`というページを作ってしまう
既にあるならそっちへリンクを表示してほしい。気づかずにページが重複していく。
## サジェストするページ
- ローマ字の大文字/小文字
- スペースのあり/なし

での間違いを教えてくれます
## 例

`MacRuby`というページが既にある時に

"macruby", "Mac Ruby", "mac ruby", "MACRU BY" などのページを作ると`MacRuby`がサジェストされます

<img src="http://gyazo.com/510bfe8f31dc7b7d5c29b2a3dd2e35f4.png">

`IP Webcam`というページが既にある時に

"IPWebcam", "ip webcam", "IP WebCam" などを作ろうとすると`IP Webcam`がサジェストされます

もちろんそのまま無視して編集もできます
## 速度

はやいです。
数千ページあるwikiで、既存のsearch.rbのlistなどの関数を使うと数秒待ちますが、これは一瞬で表示されます
## 手法

[asearch gem](https://github.com/masui/asearch-ruby) を使った。
