### PR TITLE
gyazo以外の画像も、ページの代表画像としてページリストのアイコンタイルに表示する

### DIFF
--- a/lib/related.rb
+++ b/lib/related.rb
@@ -82,8 +82,12 @@ def related_html(name,title)
     end
     @target_title = t.sub(/^\d+\/\d+\/\d+\s+\d+:\d+:\d+\s+/,'').sub(/\[\[http\S+\s+(.*)\]\]/){ $1 }
     @target_title.sub!(/^[0-9a-f]{10}-/,'') # アップロードデータ管理用のハッシュを名前から除く
-    if repimage[t] then
-      @imageurl = "http://gyazo.com/#{repimage[t]}.png"
+    if repimage[t]
+      if repimage[t] =~ /https?:\/\/.+\.(png|jpe?g|gif)/i
+        @imageurl = repimage[t]
+      else
+        @imageurl = "http://gyazo.com/#{repimage[t]}.png"
+      end
       erb :icon
     else
       length = t.split(//).length

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -121,7 +121,11 @@ def search(name,query='',namesort=false)
     if repimage[title] then
       @target_url = "#{app_root}/#{name}/#{title}"
       @target_title = title
-      @imageurl = "http://gyazo.com/#{repimage[title]}.png"
+      if repimage[t] =~ /https?:\/\/.+\.(png|jpe?g|gif)/i
+        @imageurl = repimage[t]
+      else
+        @imageurl = "http://gyazo.com/#{repimage[t]}.png"
+      end
       erb :icon
     else
       ''

--- a/lib/writedata.rb
+++ b/lib/writedata.rb
@@ -123,6 +123,8 @@ def writedata(data)
   repimage = SDBM.open("#{topdir(name)}/repimage")
   if data[0] =~ /gyazo.com\/(\w{32})\.png/i then
     repimage[title] = $1
+  elsif data[0] =~ /(https?:\/\/.+)\.(png|jpe?g|gif)/i
+    repimage[title] = "#{$1}.#{$2}"
   else
     repimage.delete(title)
   end
@@ -194,6 +196,8 @@ def __writedata(data) # 無条件書き込み
   repimage = SDBM.open("#{topdir(name)}/repimage")
   if data[0] =~ /gyazo.com\/(\w{32})\.png/i then
     repimage[title] = $1
+  elsif data[0] =~ /(https?:\/\/.+)\.(png|jpe?g|gif)/i
+    repimage[title] = "#{$1}.#{$2}"
   else
     repimage.delete(title)
   end


### PR DESCRIPTION
ページリストのタイルにはページの代表画像が表示されていますが、gyazoにホストされた画像のみが表示されます。
gyazzのupload機能でうｐされた画像はタイルにアイコン表示されません。

<img src="http://gyazo.com/65a7b5c73fdb0634a450d4393f02e58c.png">

画像であればなんでも表示するようにしました `(gif|jpe?g|png)`

なんでもではなく、gyazo/gyazzにホストされた画像のみにした方がいいのかと思ったのですが
どう書けばいいのかわからなくてこうなりました。とりあえずpull requestします。

ちなみにページの代表画像DBの更新はwritedataされた時なので、コレをmergeしてもすぐアイコンが表示されるようになるわけではありません。
次にページが保存された時に、代表画像が設定されます。
