### PR TITLE
#3 Twitterユーザー名でのアイコン表示に対応しました

### DIFF
--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -657,6 +657,19 @@ function tag(s,line){
 	else if(t = inner.match(/^@([a-zA-Z0-9_]+)$/)){ // @名前 を twitterへのリンクにする
 	    matched.push('<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank">@' + t[1] + '</a>');
 	}
+	else if(t = inner.match(/^@([a-zA-Z0-9_]+) x([0-9]+)$/)){ // @名前 x個数 でリンク付きtwitter iconを出力する
+	    var count = t[2];
+	    if(count != '0') {
+	        var icons = "";
+	        for(var i=0; i < count; i++){
+	            icons += '<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank"><img src="http://twiticon.herokuapp.com/' + t[1] + '"></a>';
+	        }
+	        matched.push(icons);
+	    }
+	    else {
+	        matched.push('<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank">@' + t[1] + '</a>');
+	    }
+	}
 	else if(t = inner.match(/^(.+)::$/)){ //  Wikiname:: で他Wikiに飛ぶ (2011 4/17)
 	    matched.push('<a href="' + root + '/' + t[1] + '" class="link" target="_blank" title="' + t[1] + '">' + t[1] + '</a>');
 	}


### PR DESCRIPTION
#3 のTwitterユーザー名によるアイコン表示対応を行いました

```
[[@bilyakudan x1]]  
```

と書くと、アイコンが1つ表示され、

```
[[@bilyakudan xN]]
```

でN個表示されます

また、

```
[[@bilyakudan x0]]
```

では、通常のTwitterユーザー名によるリンクを生成するようにしています

下記画像はx100の例です
![2013-05-31 23 32 36](https://f.cloud.github.com/assets/851025/591305/f617e212-c9fe-11e2-9e20-c8c0e992fc6d.png)

よろしくお願いいたします
