### PR TITLE
add RSS feed meta tag each page #10

### DIFF
--- a/views/page.erb
+++ b/views/page.erb
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="<%= @urlroot %>/stylesheets/gyazz.css" type="text/css">
   <link rel="apple-touch-icon" href="<%= @urlroot %>/gyazz.png">
   <link rel="shortcut icon" href="<%= @urlroot %>/favicon.ico">
+  <link rel="alternate" type="application/rss+xml" title="<%= @name %> RSS Feed" href="<%= @urlroot %>/<%= @name %>/rss.xml" />
   <meta name="robots" content="<%= @robotspec %>">
 
   <script language="JavaScript" src='<%= @urlroot %>/javascripts/pbsearch.js'></script>


### PR DESCRIPTION
#10 の実装です

RSSフィードのメタタグを全ページに埋め込みました。
Livedoor Reader等のbookmarkletからも認識されています
<img src="http://gyazo.com/c212038e62301c5e800c9cc8afe6018d.png">
