### PR TITLE
use Rack::Session::Cookie instead of "enable :sessions"  #11

### DIFF
--- a/gyazz.rb
+++ b/gyazz.rb
@@ -4,8 +4,6 @@
 require 'json'
 require 'date'
 
-enable :sessions   # Cookieを使うのに要るらしい
-
 $:.unshift File.expand_path 'lib', File.dirname(__FILE__)
 require 'lib'
 require 'config'
@@ -23,6 +21,15 @@ require 'auth'
 require 'contenttype'
 
 # require 'tmpshare'
+
+## sessionを使う
+use Rack::Session::Cookie, {
+  :key => SESSION_KEY,
+  :domain => SESSION_DOMAIN,
+  :path => '/',
+  :expire_after => 60*60*24*14, # 2 weeks
+  :secret => SESSION_SECRET
+}
 
 configure do
   set :protection, :except => :frame_options

--- a/lib/config_template.rb
+++ b/lib/config_template.rb
@@ -5,3 +5,7 @@ FILEROOT = "/tmp"
 
 # DEFAULTPAGE = "/index.html"
 DEFAULTPAGE = "/Gyazz/目次"
+
+SESSION_DOMAIN = "gyazz.com"
+SESSION_KEY    = "__session_key_____(please_change)__"
+SESSION_SECRET = "__session_secret__(please_change)__"


### PR DESCRIPTION
#11 の実装です

`enable :sessions`の代わりに`Rack::Session::Cookie`を使いました。

起動時のwarningが出なくなりました。
cookieの動作は `/.書込認証` で検証しました。

lib/config_template.rbに

``` ruby
SESSION_DOMAIN = "gyazz.com"
SESSION_KEY    = "__session_key_____(please_change)__"
SESSION_SECRET = "__session_secret__(please_change)__"
```

を追加しました。
