### PR TITLE
embed page-title-image if tagged with [[page_name x(num)]]

### DIFF
--- a/gyazz.rb
+++ b/gyazz.rb
@@ -333,6 +333,23 @@ get '/:name/*/text' do
   data
 end
 
+
+## ページの代表画像があればリダイレクトする
+get '/:name/*/icon' do
+  name = params[:name]
+  title = params[:splat].join('/')
+  repimage = SDBM.open("#{topdir(name)}/repimage")
+  img = repimage[title]
+  halt 404, "image not found" if img.to_s.empty?
+  redirect case img
+           when /^https?:\/\/.+\.(png|jpe?g|gif)$/i
+             img
+           else
+             "http://gyazo.com/#{img}.png"
+           end
+end
+
+
 get '/:name/*/text/:version' do      # 古いバージョンを取得
   name = params[:name]
 #  protected!(name)

--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -657,19 +657,28 @@ function tag(s,line){
 	else if(t = inner.match(/^@([a-zA-Z0-9_]+)$/)){ // @名前 を twitterへのリンクにする
 	    matched.push('<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank">@' + t[1] + '</a>');
 	}
-	else if(t = inner.match(/^@([a-zA-Z0-9_]+) x([0-9]+)$/)){ // @名前 x個数 でリンク付きtwitter iconを出力する
-	    var count = t[2];
-	    if(count != '0') {
-	        var icons = "";
+	else if(t = inner.match(/^@([a-zA-Z0-9_]+) x([1-9][0-9]*)$/)){ // @名前 x個数 でリンク付きtwitter iconを出力する
+	    var count = Number(t[2]);
+	    if(count > 0) {
+	        var icons = '<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank">';
 	        for(var i=0; i < count; i++){
-	            icons += '<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank"><img src="http://twiticon.herokuapp.com/' + t[1] + '/mini"></a>';
+	            icons += '<img src="http://twiticon.herokuapp.com/' + t[1] + '/mini" class="icon" height="24" border="0" />';
 	        }
+            icons += '</a>';
 	        matched.push(icons);
 	    }
-	    else {
-	        matched.push('<a href="http://twitter.com/' + t[1] + '" class="link" target="_blank">@' + t[1] + '</a>');
-	    }
 	}
+    else if(t = inner.match(/^([^\s]+) x([1-9][0-9]*)$/)){ // ページ名 x個数でページの代表画像を大量に表示する
+        var count = Number(t[2]);
+        if(count > 0){
+            var icons = '<a href="'+root+'/'+name+'/'+t[1]+'" class="link" target="_blank">';
+            for(var i = 0; i < count; i++ ){
+                icons += '<img src="'+root+'/'+name+'/'+t[1]+'/icon" class="icon" height="24" border="0" alt="'+t[1]+'" title="'+t[1]+'" />';
+            }
+            icons += '</a>';
+            matched.push(icons);
+        }
+    }
 	else if(t = inner.match(/^(.+)::$/)){ //  Wikiname:: で他Wikiに飛ぶ (2011 4/17)
 	    matched.push('<a href="' + root + '/' + t[1] + '" class="link" target="_blank" title="' + t[1] + '">' + t[1] + '</a>');
 	}


### PR DESCRIPTION
### ページ代表画像の埋め込み
# 3と同じ記法 `[[ページ名 x数字]]` でページ代表画像もたくさん並べられるようになりました。

<img src="http://gyazo.com/4ac52487699e4bb3af75cf177442d3ed.png"><img src="http://gyazo.com/dfdcb183071e50dd997b7e689a55ec1b.png">
imgタグにはheight="24"とclass="icon"を指定してあるので、あとからサイズ調整もできます。
### ページ代表画像API

ページ代表画像をimgタグで埋め込むために、`http://gyazz.com/wiki_name/page_name/icon` をページ代表画像へ302リダイレクトするAPIを追加しました。
リダイレクトなのでアイコンを100個埋め込んでもgyazz.comへのリクエストは1回だけです。
代表画像がない場合は404を返します。imgタグには代替テキスト（altとtitle）を設定してあるので、画像が無い場合は代替テキストが表示されます。

<img src="http://img.tiqav.com/Dt.th.jpg">
