### PR TITLE
twitter名を並べてグラフを作る

### DIFF
--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -647,14 +647,36 @@ function tag(s,line){
 	    matched.push('<a href="' + t[1] + '.' + t[2] + '" target="_blank"><img src="' + t[1] + '.' + t[2] + '" border="none"></a>');
 	}
     else if(t = inner.match(/^(.+)\.(png|icon)$/i)){ // ページ名.icon or ページ名.pngでアイコン表示
-        var link_to = t[1];
-        matched.push('<a href="'+root+'/'+name+'/'+link_to+'" class="link" target="_blank"><img src="'+root+'/'+name+'/'+link_to+'/icon" class="icon" height="24" border="0" alt="'+link_to+'" title="'+link_to+'" /></a>');
+        var link_to = null;
+        var img_url = null;
+        if(t[1].match(/^@[\da-z_]+$/i)){
+            var screen_name = t[1].replace(/^@/,"");
+            link_to = "http://twitter.com/"+screen_name;
+            img_url = "http://twiticon.herokuapp.com/"+screen_name+"/mini";
+        }
+        else{
+            link_to = root+"/"+name+"/"+t[1];
+            img_url = link_to+"/icon";
+        }
+        matched.push('<a href="'+link_to+'" class="link" target="_blank"><img src="'+img_url+'" class="icon" height="24" border="0" alt="'+link_to+'" title="'+link_to+'" /></a>');
     }
-    else if(t = inner.match(/^(.+)\.(png|icon|jpe?g|gif)x([1-9][0-9]*)(|\.[0-9]+)$/i)){ // (URL|ページ名).(icon|png)x個数 でアイコンをたくさん表示
-        var link_to = t[1].match(/^https?:\/\/.+$/) ? t[1]+'.'+t[2] : root+'/'+'/'+name+'/'+t[1];
+    else if(t = inner.match(/^(.+)\.(png|icon|jpe?g|gif)[x×]([1-9][0-9]*)(|\.[0-9]+)$/i)){ // (URL|ページ名).(icon|png)x個数 でアイコンをたくさん表示
+        var link_to = null;
+        var img_url = null;
+        if(t[1].match(/^@[\da-z_]+$/i)){
+            var screen_name = t[1].replace(/^@/,"");
+            link_to = "http://twitter.com/"+screen_name;
+            img_url = "http://twiticon.herokuapp.com/"+screen_name+"/mini";
+        }
+        else if(t[1].match(/^https?:\/\/.+$/)){
+            img_url = link_to = t[1]+"."+t[2];
+        }
+        else{
+            link_to = root+"/"+name+"/"+t[1];
+            img_url = link_to+"/icon";
+        }
         var count = Number(t[3]);
         var icons = '<a href="'+link_to+'" class="link" target="_blank">';
-        var img_url = t[1].match(/^https?:\/\/.+$/) ? link_to : link_to+'/icon';
         for(var i = 0; i < count; i++){
             icons += '<img src="'+img_url+'" class="icon" height="24" border="0" alt="'+t[1]+'" title="'+t[1]+'" />';
         }


### PR DESCRIPTION
#15 の拡張版です

`[[@(twitter名).(png|icon)]]` と `[[@(twitter名).(png|icon)x数字]]`のグラフ化に対応しました

これが

```
[[MacRuby.icon]]
[[Arduino.png]]
[[@masuilab.icon]]
[[@shokai_log.png]]
[[Ruby.pngx3]]
[[ymrl.iconx10]]
[[@takumibaba.iconx4]]
[[@marutaru.pngx7]]
[[shokai.iconx5.6]]
[[geta6.pngx8.4]]
[[@shokai.iconx3.14]]
[[@nekobato.pngx5.67]]
[[http://gyazo.com/7206e18c661a618617464f3fb0b9321f.pngx3]]
[[http://gyazo.com/d6f8a71bfbdece1451670bf2c181b97b.pngx4.3]]
```

こうなります
<img src="http://gyazo.com/32e0dff023ba0ea5f8066c42c542198f.png">
