### PR TITLE
ignore icon-graphs from related pages

### DIFF
--- a/lib/keyword.rb
+++ b/lib/keyword.rb
@@ -23,6 +23,7 @@ class String
           kw !~ /^javascript:/ && 
           kw !~ /pdf / && 
           kw !~ /^@/ && 
+          kw !~ /\.(png|jpe?g|gif|icon)(|x[\d\.])/i &&
           kw !~ /::/ && 
           kw !~ /^([EWNSZ][1-9][0-9\.]*)+$/ &&
           kw !~ /^[a-fA-F0-9]{32}/ then


### PR DESCRIPTION
#16 #15 で作られるアイコンを並べたグラフ画像が

関連ページリストに含まれてしまっていたのを修正しました
