### PR TITLE
検索モードがCommandとCtrlに反応するのを抑止

### DIFF
--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -215,6 +215,7 @@ $(document).keydown(function(event){
 	var kc = event.which;
 	var sk = event.shiftKey;
 	var ck = event.ctrlKey;
+	var cd = event.metaKey && !ck;
 	var i;
 	var m,m2;
 	var dst;
@@ -323,7 +324,7 @@ $(document).keydown(function(event){
 		getdata();
 	    }
 	}
-	else if(kc >= 0x30 && kc <= 0x7e && editline < 0){
+	else if(kc >= 0x30 && kc <= 0x7e && editline < 0 && !cd && !ck){
 	    $('#querydiv').css('visibility','visible').css('display','block');
 	    $('#query').focus();
 	}


### PR DESCRIPTION
編集ページでMacのCommand+Key並びにWinのCtrl+Key操作で検索モードが反応してしまうのを抑制しました

event.metaKey && !ck でCommandKey判定してます
