### PR TITLE
googlemapsのjavascript読み込みをbodyタグ内末尾に移動

### DIFF
--- a/views/page.erb
+++ b/views/page.erb
@@ -19,11 +19,6 @@
 
   <script language="JavaScript" src='<%= @urlroot %>/javascripts/listedit.js'></script>
 
-    <!-- src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-97Tqd24a0eosRi_oY4GC4RtFrf4ldqo&sensor=false"> -->
-  <script type="text/javascript"
-    src="http://maps.googleapis.com/maps/api/js?sensor=false">
-  </script>
-
   <script type="text/javascript">
 //  var name =  '<%= @name.split(/'/).join("\\'") %>';
 //  var title = '<%= @title.split(/'/).join("\\'") %>';
@@ -84,6 +79,11 @@ Search: <input type="text" id="query" autocomplete="off" onkeyup="search(event)"
   <br clear='all'>
 </div>
 <p>
+
+  <!-- src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-97Tqd24a0eosRi_oY4GC4RtFrf4ldqo&sensor=false"> -->
+  <script type="text/javascript"
+    src="http://maps.googleapis.com/maps/api/js?sensor=false">
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
#29 に関連しています

google mapsのjavascriptの読み込みが終わるまで以降のHTMLのレンダリング行われないので
bodyタグ内末尾に移動しました。

これにより低速回線での読み込み速度が露骨に速くなりました。

scriptタグの読み込み順序が変わっても問題ない事はchrome/firefox/safariで確認しました。
