### PR TITLE
Ruby1.9以上の時に、アクセス履歴視覚化用png画像生成にASCII-8BITを使うように変更

### DIFF
--- a/lib/png.rb
+++ b/lib/png.rb
@@ -8,14 +8,15 @@ require "zlib"
 
 class PNG
   def PNG.chunk(type, data)
-    [data.bytesize, type, data, Zlib.crc32(type + data)].pack("NA4A*N")
+    chunk = [data.bytesize, type, data, Zlib.crc32(type + data)].pack("NA4A*N")
+    RUBY_VERSION < "1.9" ? chunk : chunk.force_encoding("ASCII-8BIT")
   end
 
   def PNG.png(data,depth=8,color_type=2)
     height = data.length
     width = data[0].length
     out = "\x89PNG\r\n\x1a\n"
-    # out.force_encoding("ASCII-8BIT")
+    out = out.force_encoding("ASCII-8BIT") unless RUBY_VERSION < "1.9"
     out += PNG.chunk("IHDR", [width, height, depth, color_type, 0, 0, 0].pack("NNCCCCC"))
     img_data = data.map {|line| ([0] + line.flatten).pack("C*") }.join
     out += PNG.chunk("IDAT", Zlib::Deflate.deflate(img_data))


### PR DESCRIPTION
#33 を解決しました。

アクセス履歴視覚化のpng画像生成がRuby1.9/2.0で動くように修正しました。
もちろんRuby1.8.7でも今までどおり動きます。

<img src="http://gyazo.com/8fb26b6dca6cf3b5d2fefa44c6acb46a.png">

この結果、Gyazz全体がRuby1.8.7〜2.0.0で動作するようになりました。
