### PR TITLE
data配列内の文字列に正規表現をかけた時にJSエラーが出ていたバグを修正

### DIFF
--- a/public/javascripts/listedit.js
+++ b/public/javascripts/listedit.js
@@ -154,6 +154,7 @@ $(document).mousedown(function(event){
     });
 
 function indent(line){ // 先頭の空白文字の数
+    if(typeof data[line] !== "string") return 0;
     return data[line].match(/^( *)/)[1].length;
 }
 
@@ -368,7 +369,7 @@ $(document).keydown(function(event){
 
 function deleteblankdata(){ // 空白行を削除
     for(i=0;i<data.length;i++){
-	if(data[i].match(/^ *$/)){
+	if(typeof data[i] === "string" && data[i].match(/^ *$/)){
 	    data.splice(i,1);
 	}
     }
@@ -485,7 +486,7 @@ function display(delay){
 	    }
 	    else {
 		var lastchar = '';
-		if(i > 0) lastchar = data[i-1][data[i-1].length-1];
+		if(i > 0 && typeof data[i-1] === "string") lastchar = data[i-1][data[i-1].length-1];
 		if(editline == -1 && lastchar == '\\'){ // 継続行
 		    if(contline < 0) contline = i-1;
 		    s = '';
@@ -501,7 +502,9 @@ function display(delay){
 		}
 		else { // 通常行
 		    contline = -1;
-		    if(m = data[i].match(/\[\[(https:\/\/gist\.github\.com.*\?.*)\]\]/i)){ // gistエンベッド
+            var m;
+		    if(typeof data[i] === "string" &&
+               ( m = data[i].match(/\[\[(https:\/\/gist\.github\.com.*\?.*)\]\]/i) )){ // gistエンベッド
 			// https://gist.github.com/1748966 のやり方
 			var gisturl = m[1];
 			var gistFrame = document.createElement("iframe");
@@ -663,6 +666,7 @@ function align(begin,lines){ // begin番目からlines個の行を桁揃え
 }
 
 function tag(s,line){
+    if(typeof s !== "string") return;
     matched = [];
     s = s.replace(/</g,'&lt;');
     while(m = s.match(/^(.*)\[\[\[(([^\]]|\][^\]]|[^\]]\])*)\]\]\](.*)$/)){ // [[[....]]]


### PR DESCRIPTION
# bug

空行の下にさらに空行を作るとJSエラーでページ全体が停止します。ページの一番下の行でenterキーを2回以上連続で押すと発生します。
<img src="http://gyazo.com/82d2ec63a4553694bc114408d1dc9355.png">
1. 空行の下に空行作る
2. function deleteblankdata(){ // 空白行を削除 が呼ばれる
3. 現在編集中の行 (editline変数) がdata配列のlengthを超える
4. display() などが存在しない行に正規表現かける
5. jsエラー発生

という流れです。
# 対策

data配列内の要素にアクセスして正規表現をかけている全ての箇所で、要素が`typeof data[i] === "string"`かどうか事前にチェックするようにしました
