### PR TITLE
ページ名をHTML escapeする  #56

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -1,7 +1,11 @@
 helpers do
 
-  def escape_html(str)
+  def escape_jsvar(str)
     str.gsub("'"){ "\\'" }
+  end
+
+  def escape_html(str)
+    Rack::Utils.escape_html str
   end
 
   def app_root()

--- a/views/edit.erb
+++ b/views/edit.erb
@@ -11,8 +11,8 @@
     <script language="JavaScript" src='<%= @urlroot %>/javascripts/md5.js'></script>
     <script language="JavaScript" src='<%= @urlroot %>/javascripts/edit.js'></script>
     <script type='text/javascript'>
-    var name = '<%= escape_html @name %>';
-    var title = '<%= escape_html @title %>';
+    var name = '<%= escape_jsvar @name %>';
+    var title = '<%= escape_jsvar @title %>';
     var root =  '<%= @urlroot %>';
     var orig_md5 = '<%= @orig_md5 %>';
     var write_authorized = <%= @write_authorized %>;

--- a/views/icon.erb
+++ b/views/icon.erb
@@ -2,7 +2,7 @@
   <div style="height:64;width:64;margin:2;float:left">
     <center>
       <img src='<%= @imageurl %>'
-        title='<%= @target_title %>'
+        title='<%= escape_html @target_title %>'
         style='max-height:64;border:none;width:64;'
       >
       <!-- style='max-height:64;max-width:64;border:none;width:expression(document.body.clientWidth < 64? "64px" : document.body.clientWidth > 64? "64px" : "auto");' -->

--- a/views/page.erb
+++ b/views/page.erb
@@ -23,8 +23,8 @@
 //  var name =  '<%= @name.split(/'/).join("\\'") %>';
 //  var title = '<%= @title.split(/'/).join("\\'") %>';
 //  var root =  '<%= @urlroot.split(/'/).join("\\'") %>';
-  var name =  '<%= escape_html @name %>';
-  var title = '<%= escape_html @title %>';
+  var name =  '<%= escape_jsvar @name %>';
+  var title = '<%= escape_jsvar @title %>';
   var root =  '<%= @urlroot %>';
   var version = 0;
 

--- a/views/search.erb
+++ b/views/search.erb
@@ -39,7 +39,7 @@
         <% url = "#{@urltop}/#{title}" %>
         <div class="listedit0__xxx">
           <img id="<%= id %>" src="<%= @urlroot %>/<%= @name %>/<%= title %>/access.png" width=50 height=12>
-          <a href="<%= url %>" class='tag'><%= shorttitle %></a>
+          <a href="<%= url %>" class='tag'><%= escape_html shorttitle %></a>
         </div>
         <% interval = 0 %>
         <% interval = 1400 if v[5].to_i > 0 %>

--- a/views/texticon.erb
+++ b/views/texticon.erb
@@ -1,7 +1,7 @@
 <a href="<%= @target_url %>" class="links" target="_blank">
   <div style="height:64;width:64;margin:2;float:left;background-color:#<%= @r %><%= @g %><%= @b %>;overflow:hidden;word-wrap:break-word;">
     <div style="font-size:<%= @fontsize %>pt;margin:3;color:white;overflow:hidden;word-wrap:break-word;">
-      <%= @target_title %>
+      <%= escape_html @target_title %>
     </div>
   </div>
 </a>


### PR DESCRIPTION
#56 のための修正です

ページ名にHTMLタグを使っても大丈夫になりました
- escape_html関数をescape_jsvarにリネーム（実態に即して）
- Rack::Util.escapeを使ったescape_html関数を作成、ページタイトルをescapeしてから表示する

![関連ページ](http://gyazo.com/6d42fe20ab62679c369295eb85f65fc8.png)
![ページリスト](http://gyazo.com/7f339ca15b22f8cd79e85fc4aed6208f.png)

マージお願いします
![](http://gyazo.com/a0cd1a68f73ce2de0474bdb3644cb36b.png)
