### PR TITLE
新gyazz gem用に"/__write__" APIを修正 #77

### DIFF
--- a/controllers/gyazz.rb
+++ b/controllers/gyazz.rb
@@ -76,8 +76,8 @@ post '/__write' do
   Gyazz::Page.new(name,title).write(postdata,orig_md5)
 end
 
-get '/__write__' do # 無条件書き込み (gyazz-rubyで利用)
-  data = params[:data].split(/\n/)
+post '/__write__' do # 無条件書き込み (gyazz-rubyで利用)
+  data = params[:data]
   if params[:name] then
     name = params[:name]
     title = params[:title]


### PR DESCRIPTION
- 書き込みAPIが`get "/__write__"`になっていたので、`post "/__write__"`に戻しました
- APIにpostされたデータを文字列として扱うか配列として扱うかが間違っていたので、動くように直しました
