### PR TITLE
POST /__write__ APIがリダイレクト要求していた問題を修正

### DIFF
--- a/controllers/gyazz.rb
+++ b/controllers/gyazz.rb
@@ -78,21 +78,21 @@ end
 
 post '/__write__' do # 無条件書き込み (gyazz-rubyで利用)
   data = params[:data]
-  if params[:name] then
-    name = params[:name]
-    title = params[:title]
-  else # この仕様は削除すべき ********
-    name = data.shift
-    title = data.shift
+  name = params[:name]
+  title = params[:title]
+  if !data or name.to_s.empty? or title.to_s.empty?
+    halt 400, 'Bad Request: parameter "data", "name", "title" require'
   end
   Gyazz::Page.new(name,title).write(data)
-  redirect("/#{name}/#{title}")
 end
 
 get '/__write__' do # 無条件書き込み
   data = params[:data]
   name = params[:name]
   title = params[:title]
+  if !data or name.to_s.empty? or title.to_s.empty?
+    halt 400, 'Bad Request: parameter "data", "name", "title" require'
+  end
   Gyazz::Page.new(name,title).write(data)
   redirect("/#{name}/#{title}")
 end


### PR DESCRIPTION
- POST /**write** がクライアントにリダイレクトを要求していますが、APIなので静的ページの内容を再取得させる必要がないのでリダイレクトをやめました
- また、postパラメータもチェックするよう変更、status 400 (bad request)を返す
- bookmarklet用 新規ページ作成APIで、引数が足りない場合statu 400エラーを返すように修正
