### PR TITLE
Gyazz起動時にデータディレクトリを作成、uploadディレクトリのシンボリックリンクをpublicの下に作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *~
 .DS_Store
+public/upload
 data
 lib/config.rb
 .ruby-version
 .SyncID
 .SyncIgnore
-

--- a/config.ru
+++ b/config.ru
@@ -9,6 +9,7 @@ $:.unshift File.dirname(__FILE__)
 
 ## load libraries
 require 'lib/config'
+require 'lib/init'
 require 'lib/pair'
 require 'lib/keyword'
 require 'lib/png'

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -1,0 +1,12 @@
+require 'fileutils'
+
+module Gyazz
+  def self.create_directories
+    FileUtils.mkdir_p FILEROOT
+    FileUtils.mkdir_p "#{FILEROOT}/upload"
+    File.delete 'public/upload' if File.exists? 'public/upload'
+    File.symlink "#{FILEROOT}/upload", 'public/upload'
+  end
+end
+
+Gyazz::create_directories

--- a/views/page.erb
+++ b/views/page.erb
@@ -16,7 +16,7 @@
   <script language="JavaScript" src='/javascripts/md5.js'></script>
   <script language="JavaScript" src='/javascripts/location.js'></script>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="/javascripts/jquery.js"></script>
   <!-- <script language="JavaScript" src='/javascripts/jQuery.kill_referrer.js'></script> -->
   <script language="JavaScript" src='/javascripts/jquery.tipTip.js'></script>
 


### PR DESCRIPTION
#114 の実装です
- Gyazz起動時にデータディレクトリを作成、uploadディレクトリのシンボリックリンクをpublicの下に作成
- page.erbのみがgoogleがホストしているjqueryを使っていたので、自前ホストしているjqueryを使う
