### PR TITLE
ページ名サジェスト候補が無い場合、空ページをサジェストしていたbugを修正  #125

### DIFF
--- a/controllers/gyazz.rb
+++ b/controllers/gyazz.rb
@@ -273,7 +273,7 @@ get '/:name/*/json' do
 
   if data["data"].empty? or data["data"] == ["(empty)"]
     suggest_title = page.suggest_similartitles.first
-    data["data"] = ["-&gt; [[#{suggest_title}]]"]
+    data["data"] = ["-&gt; [[#{suggest_title}]]"] if suggest_title
   end
 
   # 未認証状態でなぞなぞページにアクセスしたときはテキストを並べかえる


### PR DESCRIPTION
![](http://gyazo.com/5069b315ae591da18ea0985eb7af0bc5.png)
こうなっていたバグを修正しました
