### PR TITLE
行編集モードを抜けたタイミングでページデータを保存する  #132

### DIFF
--- a/public/javascripts/gyazz.js
+++ b/public/javascripts/gyazz.js
@@ -151,7 +151,7 @@ $(document).mousedown(function(event){
     searchmode = false;
     
     if(eline == -1){ // 行以外をクリック
-	////writedata(true);
+	    writedata(true);
         editline = eline;
         calcdoi();
         display(true);


### PR DESCRIPTION
#132 の実装です

行以外の場所をクリックして編集モードを抜けた時に、現状だと保存されないので
writedata()するようにしました。

これにより1行だけのページが作れるようになりました。
