### PR TITLE
add bin/memo executable command

### DIFF
--- a/bin/memo
+++ b/bin/memo
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require 'date'
+
+cmd_name = $0.split('/').last
+
+if ARGV.empty?
+  STDERR.puts "  % #{cmd_name} masui"
+  STDERR.puts "  % #{cmd_name} (wiki_name)"
+  exit 1
+end
+
+wiki_name = ARGV.shift
+page_name = Date.today.to_s.gsub('-','')
+
+url = "http://gyazz.com/#{wiki_name}/#{page_name}"
+puts url
+system "open #{url}"


### PR DESCRIPTION
#91 の実装です。

memoコマンドを追加しました。

```
% memo masui
```

などと実行すると、日付からページ名を考えて http://gyazz.com/masui/20140408 をブラウザでopenします。
依存gemなどは無いので、memoコマンドをpathが通っている場所にコピーすればそのまま使えます。
