### PR TITLE
「編集してない時は無駄に書き込まない」処理の判定のバグを2箇所修正

### DIFF
--- a/public/javascripts/gyazz.js
+++ b/public/javascripts/gyazz.js
@@ -151,7 +151,7 @@ $(document).mousedown(function(event){
     searchmode = false;
     
     if(eline == -1){ // 行以外をクリック
-	    writedata(true);
+	    writedata();
         editline = eline;
         calcdoi();
         display(true);
@@ -492,7 +492,7 @@ function setup(){ // 初期化
 
     $('#contents').mousedown(function(event){
         if(eline == -1){ // 行以外をクリック
-            writedata(true);
+            writedata();
         }
     });
 
@@ -954,17 +954,17 @@ function tag(s,line){
     return elements.join(' ');
 };
 
-var olddatastr = '';
+var data_old = [];
 function writedata(force){
     not_saved = false;
     if(!writable) return;
 
     var datastr = data.join("\n").replace(/\n+$/,'')+"\n";
-    if(!force && datastr == olddatastr){
-	search();
-	return;
+    if(!force && (JSON.stringify(data) == JSON.stringify(data_old))){
+        search();
+        return;
     }
-    olddatastr = datastr;
+    data_old = data.concat();
 
     cache.history = {}; // 履歴cacheをリセット
 
@@ -1016,7 +1016,7 @@ function getdata(opts){ // 20050815123456.utf のようなテキストを読み�
         success: function(res){
             datestr = res['date'];
             dt = res['age'];
-            data = res['data'];
+            data_old = data = res['data'];
             orig_md5 = MD5_hexhash(utf16to8(data.join("\n").replace(/\n+$/,'')+"\n"));
             search();
         }


### PR DESCRIPTION
ブラウザ側の判定がおかしかった箇所を修正しました
これにより #127 巻き戻り問題を少し解消できるはずです
## 変更点
- getdata()した時にもdata_oldを更新する
- forceオプションを付ける意味が無い箇所があったので、付けないようにした
